### PR TITLE
added message generation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,14 @@ project(coordination_oru_ros)
 
 find_package(catkin REQUIRED rosjava_build_tools)
 
+find_package(catkin REQUIRED genjava)
+
+generate_rosjava_messages(
+  PACKAGES
+    orunav_msgs
+)
+
+
 # Set the gradle targets you want catkin's make to run by default, e.g.
 #   catkin_rosjava_setup(installApp)
 # Note that the catkin_create_rosjava_xxx scripts will usually automatically

--- a/package.xml
+++ b/package.xml
@@ -44,6 +44,7 @@
   <build_depend>rosjava</build_depend>
   <build_depend>rosjava_messages</build_depend>
   <build_depend>orunav_msgs</build_depend>
+  <build_depend>genjava</build_depend>
 
   <!-- The export tag contains other, unspecified, tags -->
   <export>


### PR DESCRIPTION
This PR adds generating the java artefacts for the `orunav_msgs`. This is needed if `orunav_msgs` is not checked out into the same workspace, e.g. on the buildfarm, but also more in general. One cannot expect the java artefacts to be available as most other ROS packages are NOT rosjava packages and hence don't provide the build artefacts. As long as Java is not an official ROS language, those messages need be generated by the rosjava packages themselves.